### PR TITLE
Fix for #1 - Intercepts filenames on HtmlReporter to truncate if length > 255

### DIFF
--- a/reporter/gen_report.js
+++ b/reporter/gen_report.js
@@ -12,6 +12,9 @@ var HtmlReporter = require('./' + path.join(
 var Collector = require('./' + path.join(
   ISTANBUL_PATH, '/lib/collector'));
 
+var FileWriter = require('./' + path.join(
+  ISTANBUL_PATH, '/lib/util/file-writer'));
+
 var dump = JSON.parse(
   fs.readFileSync(
     path.resolve(process.cwd(), process.argv[2]), 'utf8'));
@@ -32,11 +35,22 @@ Object.keys(originals).forEach(key => {
       escape(atob(originals[key]))));
 });
 
+var fileWriter = new FileWriter(false);
+
+fileWriter.writeFile = function writeFile(file, callback) {
+  if (file.length > 255) {
+    var excess = file.length - 255;
+    var baseName = path.basename(file, '.html')
+    file = file.replace(baseName, baseName.substr(0, (baseName.length - excess) - 1));
+  }
+  FileWriter.prototype.writeFile.call(fileWriter, file, callback);
+};
 
 var reporter = new HtmlReporter({
   verbose: true,
   sourceStore,
   collector,
+  writer: fileWriter
 });
 
 reporter.writeReport(collector, true);

--- a/reporter/gen_report.js
+++ b/reporter/gen_report.js
@@ -38,11 +38,8 @@ Object.keys(originals).forEach(key => {
 var fileWriter = new FileWriter(false);
 
 fileWriter.writeFile = function writeFile(file, callback) {
-  if (file.length > 255) {
-    var excess = file.length - 255;
-    var baseName = path.basename(file, '.html')
-    file = file.replace(baseName, baseName.substr(0, (baseName.length - excess) - 1));
-  }
+  var ext = path.extname(file);
+  file = file.slice(0, 255 - ext.length) + ext;
   FileWriter.prototype.writeFile.call(fileWriter, file, callback);
 };
 


### PR DESCRIPTION
# What does this PR do:

Basically adds an 'interceptor' that verifies if the filepath being written is within 255 chars long. If not, will get the difference and remove the number of characters == difference from the baseName of the file.

Fixes #1 
# Where should the reviewer start:
- Diffs
- You can check issue #1 and try the same thing with `master`and with this PR.
