### PR TITLE
Revert "Fix for #1 - Intercepts filenames on HtmlReporter to truncate if length > 255"

### DIFF
--- a/reporter/gen_report.js
+++ b/reporter/gen_report.js
@@ -12,9 +12,6 @@ var HtmlReporter = require('./' + path.join(
 var Collector = require('./' + path.join(
   ISTANBUL_PATH, '/lib/collector'));
 
-var FileWriter = require('./' + path.join(
-  ISTANBUL_PATH, '/lib/util/file-writer'));
-
 var dump = JSON.parse(
   fs.readFileSync(
     path.resolve(process.cwd(), process.argv[2]), 'utf8'));
@@ -35,19 +32,11 @@ Object.keys(originals).forEach(key => {
       escape(atob(originals[key]))));
 });
 
-var fileWriter = new FileWriter(false);
-
-fileWriter.writeFile = function writeFile(file, callback) {
-  var ext = path.extname(file);
-  file = file.slice(0, 255 - ext.length) + ext;
-  FileWriter.prototype.writeFile.call(fileWriter, file, callback);
-};
 
 var reporter = new HtmlReporter({
   verbose: true,
   sourceStore,
   collector,
-  writer: fileWriter
 });
 
 reporter.writeReport(collector, true);


### PR DESCRIPTION
Reverts samccone/coverage-ext#2

fixes #3
