### PR TITLE
Brings back the fix for #1 having into account #2

### DIFF
--- a/reporter/gen_report.js
+++ b/reporter/gen_report.js
@@ -12,6 +12,9 @@ var HtmlReporter = require('./' + path.join(
 var Collector = require('./' + path.join(
   ISTANBUL_PATH, '/lib/collector'));
 
+var FileWriter = require('./' + path.join(
+  ISTANBUL_PATH, '/lib/util/file-writer'));
+
 var dump = JSON.parse(
   fs.readFileSync(
     path.resolve(process.cwd(), process.argv[2]), 'utf8'));
@@ -32,11 +35,22 @@ Object.keys(originals).forEach(key => {
       escape(atob(originals[key]))));
 });
 
+var fileWriter = new FileWriter(false);
+
+fileWriter.writeFile = function writeFile(file, callback) {
+  var ext = path.extname(file);
+  FileWriter.prototype.writeFile.call(
+    fileWriter,
+    file.length > 255 ? file.slice(0, 255 - ext.length) + ext : file,
+    callback
+  );
+};
 
 var reporter = new HtmlReporter({
   verbose: true,
   sourceStore,
   collector,
+  writer: fileWriter
 });
 
 reporter.writeReport(collector, true);


### PR DESCRIPTION
# What does this PR do:
- Adds back the interceptor, but now verifies the file length and only slices if it is bigger than 255.
- Re-implemented it to not have side-effects (_no-param-reassign_).
# Where should the reviewer start:
- Diffs
## After improvements

`node gen_report.js ~/ctnl.coverage  2.46s user 0.28s system 102% cpu 2.673 total`
