### PR TITLE
Truncate file names in gen_report

### DIFF
--- a/reporter/gen_report.js
+++ b/reporter/gen_report.js
@@ -16,11 +16,22 @@ var dump = JSON.parse(
   fs.readFileSync(
     path.resolve(process.cwd(), process.argv[2]), 'utf8'));
 
-var originals = JSON.parse(dump.originals)
+var truncateFileNames = function (data) {
+    return Object.keys(data).reduce(function (n, path) {
+        console.log('Path', path);
+        n[path.slice(0, 200)] = data[path];
+        n[path.slice(0, 200)].path = path.slice(0, 200)
+
+        return n;
+    }, {});
+}
+
+var originals = truncateFileNames(JSON.parse(dump.originals));
 var sourceStore = new MemoryStore();
 var collector = new Collector();
+var data = truncateFileNames(JSON.parse(dump.coverage));
 
-collector.add(JSON.parse(dump.coverage));
+collector.add(data);
 
 function atob(str) {
   return new Buffer(str, 'base64').toString('binary');

--- a/reporter/gen_report.js
+++ b/reporter/gen_report.js
@@ -18,7 +18,6 @@ var dump = JSON.parse(
 
 var truncateFileNames = function (data) {
     return Object.keys(data).reduce(function (n, path) {
-        console.log('Path', path);
         n[path.slice(0, 200)] = data[path];
         n[path.slice(0, 200)].path = path.slice(0, 200)
 


### PR DESCRIPTION
I think this should fix the long filename issue. Rather than trying to mess with Istanbul internals, this will truncate the filenames as you are saving. Seems to be working for me, where it wasn't before.
